### PR TITLE
Pipe last

### DIFF
--- a/src/fest.ml
+++ b/src/fest.ml
@@ -2,6 +2,6 @@ external test : string -> (unit -> unit) -> unit = "test" [@@mel.module "node:te
 
 type assertion
 external expect : assertion = "assert" [@@mel.module]
-external equal : assertion -> 'a -> 'a -> unit = "equal" [@@mel.send]
-external strict_equal : assertion -> 'a -> 'a -> unit = "strictEqual" [@@mel.send]
+external equal : 'a -> 'a -> assertion -> unit = "equal" [@@mel.send]
+external strict_equal : 'a -> 'a -> assertion -> unit = "strictEqual" [@@mel.send]
 let strictEqual = strict_equal

--- a/test/one.ml
+++ b/test/one.ml
@@ -1,8 +1,8 @@
 open Fest
 
 let () = test "some test" (fun () ->
-  expect |. strict_equal 1 1
+  expect |> strict_equal 1 1
 )
 let () = test "second basic test" (fun () ->
-  expect |. equal "foo" "foo"
+  expect |> equal "foo" "foo"
 )

--- a/test/two.re
+++ b/test/two.re
@@ -15,5 +15,5 @@ let () =
 
     // Check that Hello component renders the name properly.
     let el = RTL.getByText(~matcher=`Str("Hello Nila"), result);
-    expect->(strictEqual(textContent(el), "Hello Nila"));
+    expect |> strictEqual(textContent(el), "Hello Nila");
   });


### PR DESCRIPTION
Melange stdlibs have recently been refactored to be friendlier towards pipe last. This PR updates the bindings to follow that convention.