### PR TITLE
docs based in context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,14 +57,13 @@ test: ## Run test suite
 
 .PHONY: docs
 docs: ## Build the docs
+	$(DUNE) build @doc
 	rm -rf _docs
 	mkdir _docs
 	cp docs/index.html _docs
-	ODOC_SYNTAX=reason $(DUNE) build @doc
 	mv _build/default/_doc/_html/odoc.support _docs
-	mv _build/default/_doc/_html/melange-fest _docs/reason
-	ODOC_SYNTAX=ocaml $(DUNE) build @doc
 	mv _build/default/_doc/_html/melange-fest _docs/ocaml
+	mv _build/reason/_doc/_html/melange-fest _docs/reason
 
 .PHONY: preview
 preview: docs ## Preview the docs

--- a/dune-workspace
+++ b/dune-workspace
@@ -1,0 +1,20 @@
+(lang dune 3.8)
+
+(context
+ (default
+  (profile ml)))
+
+(context
+ (default
+  (name reason)
+  (profile re)))
+
+; define env vars
+
+(env
+ (ml
+  (env-vars
+   (ODOC_SYNTAX ocaml)))
+ (re
+  (env-vars
+   (ODOC_SYNTAX reason))))


### PR DESCRIPTION
Continues from https://github.com/ahrefs/melange-fest/pull/7#discussion_r1512030196.

Calling `dune build @doc` will create two folders `_build/default` and `_build/reason`, with each containing the corresponding doc folder under `_doc`.