### PR TITLE
Introduce a `subtest` function and make `Promise.test` return just `unit`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 # Unreleased
 
-- Add bindings for `node:test` and `node:assert/strict`
+- Introduce a `subtest` function and make `Promise.test` return just `unit`,
+  [#10](https://github.com/ahrefs/melange-fest/pull/10)
 
 # 0.1.0
 
 - Add `Fest.ok`
+- Add bindings for `node:test` and `node:assert/strict`

--- a/src/fest.ml
+++ b/src/fest.ml
@@ -9,10 +9,14 @@ module Promise = struct
   (** {{:https://v2.ocaml.org/manual/bindingops.html }Monadic binding operator} for promises *)
   let ( let* ) p f = Js.Promise.then_ f p
 
-  external test : string -> (unit -> unit Js.Promise.t) -> unit Js.Promise.t
+  external test : string -> (unit -> unit Js.Promise.t) -> unit = "test"
+  [@@mel.module "node:test"]
+  (** Create a top-level test with a given name and callback function that runs the test and returns a promise. *)
+
+  external subtest : string -> (unit -> unit Js.Promise.t) -> unit Js.Promise.t
     = "test"
   [@@mel.module "node:test"]
-  (** Create a test with a given name and callback function that runs the test and returns a promise. *)
+  (** Create a subtest with a given name and callback function that runs the test and returns a promise. It is supposed to be used inside a {!test} function call. *)
 end
 
 type assertion

--- a/test/bindings.ml
+++ b/test/bindings.ml
@@ -27,18 +27,15 @@ module Promise = struct
   open Fest.Promise
 
   let inner input output =
-    test
+    subtest
       ("Math.defaultRound: " ^ Js.Float.toString input)
       (fun () ->
         expect
         |> equal output (input |> Js.Math.round |> int_of_float |> string_of_int);
         Js.Promise.resolve ())
 
-  let (_ : unit Js.Promise.t) =
-    let* () =
-      test "promise" (fun () ->
-          let* () = inner 0. "0" in
-          inner 0.055 "0")
-    in
-    Js.Promise.resolve ()
+  let () =
+    test "promise" (fun () ->
+        let* () = inner 0. "0" in
+        inner 0.055 "0")
 end


### PR DESCRIPTION
Modifies the `Promise` module to:
- a `subtest` function
- modify `test` to make the returned type be plain `unit` (Node guarantees that the inner promise is resolved)

See how this change makes the usage much less cumbersome in the test diff.